### PR TITLE
cleanup, ODT support, convert all colors to hexdec, plugin.info.txt

### DIFF
--- a/action.php
+++ b/action.php
@@ -8,13 +8,11 @@ if(!defined('DOKU_INC')) die();
 /**
  * Action Component for the FontColor plugin
  */
-class action_plugin_fontcolor extends DokuWiki_Action_Plugin
-{
+class action_plugin_fontcolor extends DokuWiki_Action_Plugin {
     /**
      * register the event handlers
      */
-    public function register(Doku_Event_Handler $controller)
-    {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'toolbarEventHandler', array());
     }
 
@@ -22,38 +20,37 @@ class action_plugin_fontcolor extends DokuWiki_Action_Plugin
      * Adds FontColor toolbar button
      *
      * @param Doku_Event $event
-     * @param mixed      $param
+     * @param mixed $param
      */
-    public function toolbarEventHandler(Doku_Event $event, $param)
-    {
+    public function toolbarEventHandler(Doku_Event $event, $param) {
         $colors = array(
-            'Yellow' => '#ffff00',
-            'Red' => '#ff0000',
-            'Orange' => '#ffa500',
-            'Salmon' => '#fa8072',
-            'Pink' => '#ffc0cb',
-            'Plum' => '#dda0dd',
-            'Purple' => '#800080',
-            'Fuchsia' => '#ff00ff',
-            'Silver' => '#c0c0c0',
-            'Aqua' => '#00ffff',
-            'Teal' => '#008080',
-            'Cornflower' => '#6495ed',
-            'Sky Blue' => '#87ceeb',
-            'Aquamarine' => '#7fffd4',
-            'Pale Green' => '#98fb98',
-            'Lime' => '#00ff00',
-            'Green' => '#008000',
-            'Olive' => '#808000',
-            'Indian Red' => '#cd5c5c',
-            'Khaki' => '#f0e68c',
-            'Powder Blue' => '#b0e0e6',
-            'Sandy Brown' => '#f4a460',
-            'Steel Blue' => '#4682b4',
-            'Thistle' => '#d8bfd8',
-            'Yellow Green' => '#9acd32',
-            'Dark Violet' => '#9400d3',
-            'Maroon' => '#800000'
+            'Yellow'        => '#ffff00',
+            'Red'           => '#ff0000',
+            'Orange'        => '#ffa500',
+            'Salmon'        => '#fa8072',
+            'Pink'          => '#ffc0cb',
+            'Plum'          => '#dda0dd',
+            'Purple'        => '#800080',
+            'Fuchsia'       => '#ff00ff',
+            'Silver'        => '#c0c0c0',
+            'Aqua'          => '#00ffff',
+            'Teal'          => '#008080',
+            'Cornflower'    => '#6495ed',
+            'Sky Blue'      => '#87ceeb',
+            'Aquamarine'    => '#7fffd4',
+            'Pale Green'    => '#98fb98',
+            'Lime'          => '#00ff00',
+            'Green'         => '#008000',
+            'Olive'         => '#808000',
+            'Indian Red'    => '#cd5c5c',
+            'Khaki'         => '#f0e68c',
+            'Powder Blue'   => '#b0e0e6',
+            'Sandy Brown'   => '#f4a460',
+            'Steel Blue'    => '#4682b4',
+            'Thistle'       => '#d8bfd8',
+            'Yellow Green'  => '#9acd32',
+            'Dark Violet'   => '#9400d3',
+            'Maroon'        => '#800000'
         );
 
         $button = array(
@@ -63,7 +60,7 @@ class action_plugin_fontcolor extends DokuWiki_Action_Plugin
             'list' => array()
         );
 
-        foreach ($colors as $colorName => $colorValue) {
+        foreach($colors as $colorName => $colorValue) {
             $button['list'] [] = array(
                 'type' => 'format',
                 'title' => $colorName,

--- a/action.php
+++ b/action.php
@@ -3,10 +3,7 @@
  * Action Component for the FontColor plugin
  */
 
-if (!defined('DOKU_PLUGIN')) {
-    define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
-}
-require_once DOKU_PLUGIN . 'action.php';
+if(!defined('DOKU_INC')) die();
 
 /**
  * Action Component for the FontColor plugin

--- a/images/color-icon.php
+++ b/images/color-icon.php
@@ -11,4 +11,5 @@ if ($isSameHost && $isColorSet) {
     header('Content-type: image/png');
     header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 60*60*24*365) . ' GMT');
     imagepng($img);
+    imagedestroy($img);
 }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   fontcolor
 author Thorsten Stratmann
 email  Thorsten.Stratmann@web.de
-date   2014-10-23
+date   2014-10-24
 name   fontcolor plugin
 desc   Write text in various colors
-url    http://www.dokuwiki.org/plugin:fontcolor
+url    https://www.dokuwiki.org/plugin:fontcolor

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   fontcolor
 author Thorsten Stratmann
 email  Thorsten.Stratmann@web.de
-date   2010-03-23
+date   2014-10-23
 name   fontcolor plugin
 desc   Write text in various colors
 url    http://www.dokuwiki.org/plugin:fontcolor

--- a/syntax.php
+++ b/syntax.php
@@ -16,6 +16,8 @@ if(!defined('DOKU_INC')) die();
  */
 class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
 
+    protected $odt_styles;
+
     /**
      * What kind of syntax are we?
      *

--- a/syntax.php
+++ b/syntax.php
@@ -74,7 +74,7 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @param string $mode
      * @return bool
      */
-    function accepts($mode) {
+    public function accepts($mode) {
         if($mode == 'plugin_fontcolor') return true;
         return parent::accepts($mode);
     }
@@ -165,7 +165,7 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @param string $color
      * @return bool|string
      */
-    public function _color2hexdec($color) {
+    protected function _color2hexdec($color) {
         $less = new lessc();
         $less->importDir[] = DOKU_INC;
 
@@ -188,7 +188,7 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @param string $c
      * @return int
      */
-    public function _isValid($c) {
+    protected function _isValid($c) {
 
         $c = trim($c);
 

--- a/syntax.php
+++ b/syntax.php
@@ -4,7 +4,7 @@
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     modified by ThorstenStratmann <thorsten.stratmann@web.de>
- * @link       http://www.dokuwiki.org/plugin:fontcolor
+ * @link       https://www.dokuwiki.org/plugin:fontcolor
  * @version    3.1
  */
 
@@ -103,7 +103,7 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
             case DOKU_LEXER_EXIT :
                 break;
         }
-        return array($state, "#ff0");
+        return array($state, "#ffff00");
     }
 
     /**
@@ -140,7 +140,7 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
                         $stylename = "ColorizedText" . count($this->odt_styles);
                         $this->odt_styles[$style_index] = $stylename;
 
-                        //Attention: ODT only accepts hexidecimal colors
+                        //Attention: ODT only accepts hexidecimal colors of format #ffffff, not #fff.
                         $color = $color ? 'fo:color="' . $color . '" ' : '';
                         $renderer->autostyles[$stylename] = '
         <style:style style:name="' . $stylename . '" style:family="text">

--- a/syntax.php
+++ b/syntax.php
@@ -7,65 +7,91 @@
  * @link       http://www.dokuwiki.org/plugin:fontcolor
  * @version    3.1
  */
- 
-if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
- 
+
+if(!defined('DOKU_INC')) die();
+
 /**
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
 class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
- 
-    function getInfo(){  // return some info
-        return array(
-            'author' => 'ThorstenStratmann',
-            'email'  => 'thorsten.stratmann@web.de',
-            'date'   => '2009-02-04',
-            'name'   => 'fontcolor Plugin',
-            'desc'   => 'color text with a specific color
-                         Syntax: <fc color>Your Text </fc>',
-            'url'    => 'http://www.dokuwiki.org/plugin:fontcolor',
-        );
-    }
- 
-     // What kind of syntax are we?
-    function getType(){ return 'formatting'; }
- 
-    // What kind of syntax do we allow (optional)
-    function getAllowedTypes() {
+
+    /**
+     * What kind of syntax are we?
+     *
+     * @return string
+     */
+    public function getType(){ return 'formatting'; }
+
+    /**
+     * What kind of syntax do we allow (optional)
+     *
+     * @return array
+     */
+    public function getAllowedTypes() {
         return array('formatting', 'substition', 'disabled');
     }
- 
-   // What about paragraphs? (optional)
-   function getPType(){ return 'normal'; }
- 
-    // Where to sort in?
-    function getSort(){ return 90; }
- 
- 
-    // Connect pattern to lexer
-    function connectTo($mode) {
-      $this->Lexer->addEntryPattern('(?i)<fc(?: .+?)?>(?=.+</fc>)',$mode,'plugin_fontcolor');
+
+    /**
+     * What about paragraphs? (optional)
+     *
+     * @return string
+     */
+    public function getPType(){ return 'normal'; }
+
+    /**
+     * Where to sort in?
+     *
+     * @return int
+     */
+    public function getSort(){ return 90; }
+
+    /**
+     * Connect pattern to lexer
+     *
+     * @param string $mode
+     */
+    public function connectTo($mode) {
+      $this->Lexer->addEntryPattern('<fc.*?>(?=.*?</fc>)',$mode,'plugin_fontcolor');
+        $this->Lexer->addEntryPattern('<FC.*?>(?=.*?</FC>)',$mode,'plugin_fontcolor');
+
     }
-    function postConnect() {
-      $this->Lexer->addExitPattern('(?i)</fc>','plugin_fontcolor');
+    public function postConnect() {
+      $this->Lexer->addExitPattern('</fc>','plugin_fontcolor');
+        $this->Lexer->addExitPattern('</FC>','plugin_fontcolor');
     }
- 
- 
-    // Handle the match
-    function handle($match, $state, $pos, &$handler){
+
+    /**
+     * override default accepts() method to allow nesting - ie, to get the plugin accepts its own entry syntax
+     *
+     * @param string $mode
+     * @return bool
+     */
+    function accepts($mode) {
+        if ($mode == 'plugin_fontcolor') return true;
+        return parent::accepts($mode);
+    }
+
+    /**
+     * Handle the match
+     *
+     * @param   string       $match   The text matched by the patterns
+     * @param   int          $state   The lexer state for the match
+     * @param   int          $pos     The character position of the matched text
+     * @param   Doku_Handler $handler The Doku_Handler object
+     * @return  array Return an array with all data you want to use in render
+     */
+    public function handle($match, $state, $pos, $handler){
         switch ($state) {
           case DOKU_LEXER_ENTER :
-            preg_match("/(?i)<fc (.+?)>/", $match, $color); // get the color
-            if ( $this->_isValid($color[1]) ) return array($state, $color[1]);
+            $color = substr($match, 4, -1);// get the color
+            if ( $this->_isValid($color) ) return array($state, $color);
             break;
           case DOKU_LEXER_MATCHED :
             break;
           case DOKU_LEXER_UNMATCHED :
-            return array($state, $match);
-            break;
+              $handler->_addCall('cdata', array($match), $pos);
+              return false;
           case DOKU_LEXER_EXIT :
             break;
           case DOKU_LEXER_SPECIAL :
@@ -73,10 +99,18 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
         }
         return array($state, "#ff0");
     }
- 
-    // Create output
-    function render($mode, &$renderer, $data) {
+
+    /**
+     *  Create output
+     *
+     * @param   $mode   string        output format being rendered
+     * @param   $renderer Doku_Renderer the current renderer object
+     * @param   $data     array         data created by handler()
+     * @return  boolean                 rendered correctly?
+     */
+    public function render($mode, $renderer, $data) {
         if($mode == 'xhtml'){
+            /** @var $renderer Doku_Renderer_xhtml */
           list($state, $color) = $data;
           switch ($state) {
             case DOKU_LEXER_ENTER :
@@ -85,7 +119,6 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
             case DOKU_LEXER_MATCHED :
               break;
             case DOKU_LEXER_UNMATCHED :
-              $renderer->doc .= $renderer->_xmlEntities($color);
               break;
             case DOKU_LEXER_EXIT :
               $renderer->doc .= "</span>";
@@ -97,24 +130,28 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
         }
         return false;
     }
- 
-    // validate color value $c
-    // this is cut price validation - only to ensure the basic format is
-    // correct and there is nothing harmful
-    // three basic formats  "colorname", "#fff[fff]", "rgb(255[%],255[%],255[%])"
-    function _isValid($c) {
- 
+
+    /**
+     * validate color value $c
+     * this is cut price validation - only to ensure the basic format is
+     * correct and there is nothing harmful
+     * three basic formats  "colorname", "#fff[fff]", "rgb(255[%],255[%],255[%])"
+     *
+     * @param string $c
+     * @return int
+     */
+    public function _isValid($c) {
+
         $c = trim($c);
- 
+
         $pattern = "/
             (^[a-zA-Z]+$)|                                #colorname - not verified
             (^\#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$)|        #colorvalue
             (^rgb\(([0-9]{1,3}%?,){2}[0-9]{1,3}%?\)$)     #rgb triplet
             /x";
- 
+
         return (preg_match($pattern, $c));
- 
     }
 }
- 
+
 //Setup VIM: ex: et ts=4 sw=4 enc=utf-8 :

--- a/syntax.php
+++ b/syntax.php
@@ -21,7 +21,9 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      *
      * @return string
      */
-    public function getType(){ return 'formatting'; }
+    public function getType() {
+        return 'formatting';
+    }
 
     /**
      * What kind of syntax do we allow (optional)
@@ -37,14 +39,18 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      *
      * @return string
      */
-    public function getPType(){ return 'normal'; }
+    public function getPType() {
+        return 'normal';
+    }
 
     /**
      * Where to sort in?
      *
      * @return int
      */
-    public function getSort(){ return 90; }
+    public function getSort() {
+        return 90;
+    }
 
     /**
      * Connect pattern to lexer
@@ -52,13 +58,14 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @param string $mode
      */
     public function connectTo($mode) {
-      $this->Lexer->addEntryPattern('<fc.*?>(?=.*?</fc>)',$mode,'plugin_fontcolor');
-        $this->Lexer->addEntryPattern('<FC.*?>(?=.*?</FC>)',$mode,'plugin_fontcolor');
+        $this->Lexer->addEntryPattern('<fc.*?>(?=.*?</fc>)', $mode, 'plugin_fontcolor');
+        $this->Lexer->addEntryPattern('<FC.*?>(?=.*?</FC>)', $mode, 'plugin_fontcolor');
 
     }
+
     public function postConnect() {
-      $this->Lexer->addExitPattern('</fc>','plugin_fontcolor');
-        $this->Lexer->addExitPattern('</FC>','plugin_fontcolor');
+        $this->Lexer->addExitPattern('</fc>', 'plugin_fontcolor');
+        $this->Lexer->addExitPattern('</FC>', 'plugin_fontcolor');
     }
 
     /**
@@ -68,34 +75,34 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @return bool
      */
     function accepts($mode) {
-        if ($mode == 'plugin_fontcolor') return true;
+        if($mode == 'plugin_fontcolor') return true;
         return parent::accepts($mode);
     }
 
     /**
      * Handle the match
      *
-     * @param   string       $match   The text matched by the patterns
-     * @param   int          $state   The lexer state for the match
-     * @param   int          $pos     The character position of the matched text
+     * @param   string $match The text matched by the patterns
+     * @param   int $state The lexer state for the match
+     * @param   int $pos The character position of the matched text
      * @param   Doku_Handler $handler The Doku_Handler object
      * @return  array Return an array with all data you want to use in render
      */
-    public function handle($match, $state, $pos, $handler){
-        switch ($state) {
-          case DOKU_LEXER_ENTER :
-            $color = substr($match, 4, -1);// get the color
-            if ( $this->_isValid($color) ) return array($state, $color);
-            break;
-          case DOKU_LEXER_MATCHED :
-            break;
-          case DOKU_LEXER_UNMATCHED :
-              $handler->_addCall('cdata', array($match), $pos);
-              return false;
-          case DOKU_LEXER_EXIT :
-            break;
-          case DOKU_LEXER_SPECIAL :
-            break;
+    public function handle($match, $state, $pos, $handler) {
+        switch($state) {
+            case DOKU_LEXER_ENTER :
+                $color = substr($match, 4, -1); // get the color
+                if($this->_isValid($color)) return array($state, $color);
+                break;
+            case DOKU_LEXER_MATCHED :
+                break;
+            case DOKU_LEXER_UNMATCHED :
+                $handler->_addCall('cdata', array($match), $pos);
+                return false;
+            case DOKU_LEXER_EXIT :
+                break;
+            case DOKU_LEXER_SPECIAL :
+                break;
         }
         return array($state, "#ff0");
     }
@@ -109,24 +116,24 @@ class syntax_plugin_fontcolor extends DokuWiki_Syntax_Plugin {
      * @return  boolean                 rendered correctly?
      */
     public function render($mode, $renderer, $data) {
-        if($mode == 'xhtml'){
+        if($mode == 'xhtml') {
             /** @var $renderer Doku_Renderer_xhtml */
-          list($state, $color) = $data;
-          switch ($state) {
-            case DOKU_LEXER_ENTER :
-              $renderer->doc .= "<span style=\"color: $color\">";
-              break;
-            case DOKU_LEXER_MATCHED :
-              break;
-            case DOKU_LEXER_UNMATCHED :
-              break;
-            case DOKU_LEXER_EXIT :
-              $renderer->doc .= "</span>";
-              break;
-            case DOKU_LEXER_SPECIAL :
-              break;
-          }
-          return true;
+            list($state, $color) = $data;
+            switch($state) {
+                case DOKU_LEXER_ENTER :
+                    $renderer->doc .= "<span style=\"color: $color\">";
+                    break;
+                case DOKU_LEXER_MATCHED :
+                    break;
+                case DOKU_LEXER_UNMATCHED :
+                    break;
+                case DOKU_LEXER_EXIT :
+                    $renderer->doc .= "</span>";
+                    break;
+                case DOKU_LEXER_SPECIAL :
+                    break;
+            }
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Fixes #6 ODT support
Fixes #5 nested colors

Uses LESS parser to convert all colors to hexidecimal values. Included colornames.

Clean up of issues as well:
Close #2 - already fixed
Close #8 - this pull request updates plugin update date as well.